### PR TITLE
Use pathlib under Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Makes sending emails easy and DRY — For Python 3.
 __Drymail__ is a minimalist wrapper over Python’s existing [smtplib](https://docs.python.org/3/library/smtplib.html) and [email](https://docs.python.org/3/library/email.html) libraries, designed to be friendly but unrestrictive. Here’s how you might send a simple email with an attachment using _drymail_.
 
 ```python
+import pathlib
 from drymail import SMTPMailer, Message
 
 client = SMTPMailer(host='smtp.email.com', user='johndoe', password='password', tls=True)
 message = Message(subject='Congrats on the new job!', sender=('John Doe', 'john@email.com'), 
                   receivers=[('Jane Doe', 'jane@message.com'), 'jane.doe@mail.io'], text='When is the party? ;)')
-with open('congrats.pdf', 'rb') as pdf_file:
-    message.attach(filename='congrats.pdf', data=pdf_file.read(), mimetype='application/pdf')
+message.attach(filename='congrats.pdf', data=pathlib.Path('congrats.pdf').read_bytes(), mimetype='application/pdf')
 
 client.send(message)
 ```


### PR DESCRIPTION
If targeting only Python 3, `pathlib` is the preferred api instead of `open`.