### PR TITLE
Attachments added to the end of the message (backward compatible version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # drymail
-Makes sending emails easy and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) — For Python 3.  
+Makes sending emails easy and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) — For Python 3.
 
 [![PyPI version](https://badge.fury.io/py/drymail.svg)](https://badge.fury.io/py/drymail)
 
@@ -9,10 +9,9 @@ __Drymail__ is a minimalist wrapper over Python’s existing [smtplib](https://d
 from drymail import SMTPMailer, Message
 
 client = SMTPMailer(host='smtp.email.com', user='johndoe', password='password', tls=True)
-message = Message(subject='Congrats on the new job!', sender=('John Doe', 'john@email.com'), 
+message = Message(subject='Congrats on the new job!', sender=('John Doe', 'john@email.com'),
                   receivers=[('Jane Doe', 'jane@message.com'), 'jane.doe@mail.io'], text='When is the party? ;)')
-with open('congrats.pdf', 'rb') as pdf_file:
-    message.attach(filename='congrats.pdf', data=pdf_file.read(), mimetype='application/pdf')
+message.attach(filename='/path/to/congrats.pdf', mimetype='application/pdf')
 
 client.send(message)
 ```

--- a/drymail.py
+++ b/drymail.py
@@ -9,7 +9,7 @@ from smtplib import SMTP, SMTP_SSL, SMTPServerDisconnected
 
 import mistune
 from bs4 import BeautifulSoup
-
+from os.path import basename
 
 class SMTPMailer:
     """
@@ -258,6 +258,7 @@ class Message:
         self.text = text or ''
         self.html = html or ''
         self.__attachments = []
+        self.__attachments_data = []
         self.prepared_message = prepared_message
         self.prepared = False
         self.message = MIMEMultipart('mixed')
@@ -279,33 +280,42 @@ class Message:
         """
         return self.__attachments
 
-    def attach(self, data, filename, mimetype=None):
+    def attach(self, filename, data=None, mimetype=None):
         """
         Add a file as attachment to the email.
 
         Parameters
         ----------
-        data: bytes
-            The raw content of the file to be attached.
         filename : str
-            The name of the file to be attached.
+            If data is provoded:
+                The filename of the file to be attached.
+            If data not provoded:
+                The full name (path + filename) of the
+                file to be attached.
+        data: bytes, optional
+            The raw content of the file to be attached.
         mimetype : str, optional
             The MIMEType of the file to be attached.
         """
         if self.prepared_message:
             return
 
+        filename_only = basename(filename)
         if not mimetype:
             mimetype, encoding = mimetypes.guess_type(filename)
             if mimetype is None or encoding is not None:
                 mimetype = 'application/octet-stream'
-        maintype, subtype = mimetype.split('/', 1)
-        attachment = MIMEBase(maintype, subtype)
-        attachment.set_payload(data)
-        encoders.encode_base64(attachment)
-        attachment.add_header('Content-Disposition', 'attachment', filename=filename)
-        self.message.attach(attachment)
-        self.__attachments.append(filename)
+        if data:
+            maintype, subtype = mimetype.split('/', 1)
+            attachment = MIMEBase(maintype, subtype)
+            attachment.set_payload(data)
+            encoders.encode_base64(attachment)
+            attachment.add_header('Content-Disposition', 'attachment', filename=filename_only)
+            self.message.attach(attachment)
+        else:
+            self.__attachments_data.append([filename, mimetype])
+        if filename_only not in self.__attachments:
+            self.__attachments.append(filename_only)
 
     def prepare(self):
         """
@@ -339,4 +349,8 @@ class Message:
         body.attach(plaintext_part)
         body.attach(html_part)
         self.message.attach(body)
+        if self.__attachments_data:
+            for attachment_data in self.__attachments_data:
+                with open(attachment_data[0], 'rb') as a_file:
+                    self.attach(filename=basename(attachment_data[0]), data=a_file.read(), mimetype=attachment_data[1])
         self.prepared = True


### PR DESCRIPTION
Since you haven't yet had a look at the other PR, this one would be much better, since it provides backward compatibility

Changed **attach** to
```python
def attach(self, filename, data=None, mimetype=None):
```

If **data** is not provided, **filename** should be **_full path_** to a file, which will be placed at the end of the file. If **data** is provided, the behavior remains as it was up until now

Still relevant to #4 