### PR TITLE
Allow ssl context to be set for TLS connections

### DIFF
--- a/drymail.py
+++ b/drymail.py
@@ -62,13 +62,14 @@ class SMTPMailer:
         self.tls = tls
         if ssl:
             self.port = port or 465
-            self.__ssloptions = dict()
-            for key in ['keyfile', 'certfile', 'context']:
-                self.__ssloptions[key] = kwargs.get(key, None)
         elif tls:
             self.port = port or 587
         else:
             self.port = port or 25
+        if kwargs is not None:
+            self.__ssloptions = dict()
+            for key in ['keyfile', 'certfile', 'context']:
+                self.__ssloptions[key] = kwargs.get(key, None)
         self.user = user
         self.password = password
         self.connected = False
@@ -82,7 +83,7 @@ class SMTPMailer:
                                                                                **self.__ssloptions)
         self.client.ehlo()
         if self.tls:
-            self.client.starttls()
+            self.client.starttls(**self.__ssloptions)
             self.client.ehlo()
         if self.user and self.password:
             self.client.login(self.user, self.password)


### PR DESCRIPTION
When I tried using drymail to connect to our Exchange server to send mails it was failing with SSL version errors. 
I found that the following code worked to send a mail:
```
sslContext = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
connection = smtplib.SMTP('mail.server.com', 587)
connection.ehlo()
connection.starttls(context=sslContext)
connection.ehlo()
connection.login('username, 'password')
connection.sendmail("someone@server.com", "someone@server.com", "test message")
```

My proposed change allows the ssl context to be set for TLS connections as well so now I can do this and it works:
```
sslContext = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
client = SMTPMailer(host='mail.server.com',
                    user='username',
                    password='password',
                    port=587,
                    tls=True,
                    context=sslContext)
```